### PR TITLE
fix: up pid limit to 8096 from 1024

### DIFF
--- a/modules/nixos/unifi-os-server/default.nix
+++ b/modules/nixos/unifi-os-server/default.nix
@@ -267,6 +267,7 @@ in
       extraOptions = [
         "--systemd=always"
         "--add-host=host.docker.internal:host-gateway"
+        "--pids-limit=8192"
       ]
       ++ cfg.extraOptions;
     };


### PR DESCRIPTION
The container was basically non functional for me without this change (couldn't update network server, etc.).
For some more context on why the container needs so many pids, see discussion here:
https://discourse.nixos.org/t/unifi-os-server-on-nixos/76039/13